### PR TITLE
fix: correct transaction handling in webhook and add email retry

### DIFF
--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -15,6 +16,7 @@ import { CreateInitialCompanyDto } from '../companies/dto/create-initial-company
 
 @Injectable()
 export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
   private readonly secretKey = process.env.PAGARME_SECRET_KEY;
   private readonly baseUrl = process.env.PAGARME_LINK_BASE_URL;
 
@@ -126,17 +128,17 @@ export class PaymentsService {
         );
       }
 
+      if (payment.status === 'paid') {
+        return;
+      }
+
       const queryRunner = this.dataSource.createQueryRunner();
       await queryRunner.connect();
       await queryRunner.startTransaction();
 
       try {
-        if (payment.status === 'paid') {
-          return;
-        }
-
         payment.status = 'paid';
-        await this.paymentIntentRepository.save(payment);
+        await queryRunner.manager.save(payment);
 
         const companyData: CreateInitialCompanyDto = {
           nomeFantasia: payment.nomeFantasia,
@@ -166,16 +168,37 @@ export class PaymentsService {
         );
 
         await queryRunner.commitTransaction();
-
-        await this.mailService.sendActivationAccountEmail({
-          email: payment.email,
-        });
       } catch (error) {
         await queryRunner.rollbackTransaction();
 
         throw error;
       } finally {
         await queryRunner.release();
+      }
+
+      const maxRetries = 3;
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          await this.mailService.sendActivationAccountEmail({
+            email: payment.email,
+          });
+          break;
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          this.logger.error(
+            `Falha ao enviar email de ativação (tentativa ${attempt}/${maxRetries}): ${message}`,
+          );
+
+          if (attempt === maxRetries) {
+            this.logger.error(
+              `Todas as ${maxRetries} tentativas de envio de email falharam para: ${payment.email}`,
+            );
+            break;
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, 2000 * attempt));
+        }
       }
     }
   }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -58,11 +58,17 @@ export class UsersService {
       throw new ConflictException('Já existe um usuário com o mesmo email.');
     }
 
-    const companyRepository = await manager.getRepository(Company);
+    const company = manager
+      ? await manager
+          .getRepository(Company)
+          .findOne({ where: { id: createInitialUserDto.empresaId } })
+      : await this.companiesService.findById(createInitialUserDto.empresaId);
 
-    const company = await companyRepository.findOne({
-      where: { id: createInitialUserDto.empresaId },
-    });
+    if (!company) {
+      throw new NotFoundException(
+        `Empresa não encontrada com id: ${createInitialUserDto.empresaId}`,
+      );
+    }
 
     createInitialUserDto.email = createInitialUserDto.email
       .trim()


### PR DESCRIPTION
## Summary
- Fix `TransactionNotStartedError` in webhook by moving email sending outside the transaction scope
- Move early return check (`payment.status === 'paid'`) before `queryRunner` creation to avoid orphaned transactions
- Use `queryRunner.manager.save()` for payment status update so it participates in the transaction
- Add retry mechanism (3 attempts with linear backoff) for activation email sending with proper logging
- Fix null safety issues in `createInitialUser`: add fallback when `manager` is not provided and null check for company lookup

## Test plan
- [x] Send webhook payload with valid `pagarmeId` — payment updated to `paid`, company and user created
- [x] Email retry triggered 3 times with backoff on SMTP failure
- [x] Transaction committed successfully despite email failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)